### PR TITLE
Fix issue with D v2.098.1 and std.typecons.Nullable

### DIFF
--- a/src/prettyprint.d
+++ b/src/prettyprint.d
@@ -258,7 +258,7 @@ private Nullable!Tree parse(ref QuotedText textRange, string expectedClosers = "
 
         textRange = closer.consumeQuote;
 
-        return prefix.empty ? Nullable!Tree() : textRange.parseSuffix(Tree(prefix)).nullable;
+        return prefix.empty ? Nullable!Tree() : Nullable!Tree(textRange.parseSuffix(Tree(prefix)));
     }
 
     const prefix = textRange.textUntil(parenStart);
@@ -267,7 +267,7 @@ private Nullable!Tree parse(ref QuotedText textRange, string expectedClosers = "
     {
         textRange = parenStart.consumeQuote;
 
-        return prefix.empty ? Nullable!Tree() : textRange.parseSuffix(Tree(prefix)).nullable;
+        return prefix.empty ? Nullable!Tree() : Nullable!Tree(textRange.parseSuffix(Tree(prefix)));
     }
 
     const parenType = () {
@@ -307,7 +307,7 @@ private Nullable!Tree parse(ref QuotedText textRange, string expectedClosers = "
 
             textRange.popFront;
 
-            return textRange.parseSuffix(Tree(prefix, Nullable!ParenType(parenType), children)).nullable;
+            return Nullable!Tree(textRange.parseSuffix(Tree(prefix, Nullable!ParenType(parenType), children)));
         }
 
         auto child = textRange.parse(parenType.closingWithComma);


### PR DESCRIPTION
This fixes an issue I encountered with D v2.098.1, where the `.nullable` suffix on a Tree construction was failing with an error. Example:

```
~/dlang/dmd-2.098.1/linux/bin64/../../src/phobos/std/typecons.d(3100,23): Error: variable `std.typecons.nullable!(Tree).nullable.__copytmp1408` `inout` variables can only be declared inside `inout` functions
~/dlang/dmd-2.098.1/linux/bin64/../../src/phobos/std/typecons.d(3100,23): Error: `inout` constructor `prettyprint.Tree.this` creates mutable object, not inout
src/prettyprint.d(312,96): Error: template instance `std.typecons.nullable!(Tree)` error instantiating
```

Adding an explicit `Nullable` constructor fixes the issue.